### PR TITLE
Api-guidelines-update

### DIFF
--- a/src/data/guidelinesData.ts
+++ b/src/data/guidelinesData.ts
@@ -10,7 +10,8 @@ import Art from "./arts";
 import { ArrayDao } from "./dao";
 import { GUID } from "./guid";
 import { ArtKey, Level, Spell, SpellGuideline } from "./spells";
-import { Identified, NotFoundError } from "./utils";
+import { Identified } from "@/lib/utils";
+import { NotFoundError } from "@/lib/exception";
 import { log } from "console";
 
 /**
@@ -30,11 +31,11 @@ export function getArtKey(art: GUID | ArtKey | Art): ArtKey {
             return value.abbrev;
         },
         (error) => {
-            throw new NotFoundError({ message: "Art not found", cause: error, details: "Referred art does not exist" });
+            throw new NotFoundError<typeof error, string>({ message: "Art not found", cause: error, details: "Referred art does not exist" });
         }
     ));
     if (result === undefined) {
-        throw new NotFoundError({ message: "Art not found", cause: undefined, details: "Referred art does not exist" });
+        throw new NotFoundError<void, string>({ message: "Art not found", details: "Referred art does not exist" });
     } else {
         return result;
     }

--- a/src/data/spells.ts
+++ b/src/data/spells.ts
@@ -345,6 +345,20 @@ export class ArtKey {
     }
 
     /**
+     * Create an art key from art name.
+     * @param artName The art name.
+     * @param length The length of the art abbreviation.
+     * @returns The art key created from the art name.
+     * @throws {SyntaxError} The art name was not a valid art name. 
+     */
+    static fromArtName(artName: string, length: number = 2): ArtKey {
+        if (!Art.ArtNameRegex().test(artName)) {
+            throw new SyntaxError("Invalid art name");
+        }
+        return new ArtKey(artName.substring(0, length));
+    }
+
+    /**
      * The representation of the art key.
      */
     private rep: string;

--- a/src/lib/exception.ts
+++ b/src/lib/exception.ts
@@ -1,8 +1,3 @@
-/**
- * The error for not found value.
- */
-export const NotFoundError = "Not Found";
-
 
 /**
  * The exception pojo for serialization of an exception.
@@ -57,6 +52,13 @@ export class Exception<CAUSE = undefined, DETAILS = undefined> extends Error {
             ...(this.cause ? { cause: this.cause } : {}),
             ...(this.details ? { details: this.details } : {})
         });
+    }
+}
+
+export class NotFoundError<CAUSE = void, DETAIL = any> extends Exception<CAUSE, DETAIL> {
+
+    constructor({cause, message = "Resource not found", details}:{message: string, cause?: CAUSE, details?: DETAIL}) {
+        super({message, cause, details});
     }
 }
 


### PR DESCRIPTION
The changes to use @/lib/utils and @/lib/exception

Changes to be committed:
	modified:   src/data/guidelinesData.ts
    - refactor: imports from @/lib/exception instead of @/data/utils
    - refactor: imports from @/lib/utils isntead of @/data/utils
    - fix: creation of NotFoundError