### PR TITLE
doc: database initialization and environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ directory of the project.
 These variables determines the API access values.
 They may be set in user's environment, or in the user environment file .env.
 
+The development settigns may assign development specific variables to the ".env.development", but the 
+shared environment file ".env" overwrites any changes in that file. 
+
+Similar fashion the production specific variables may be put into the ".env.production", but the 
+shared environment file ".env" overwrites any changes in that file. 
+
+Test environment may be assigned to the ".env.test", but test environment variables has to be given
+"VITE_"-prefix due vitest security protecting the environment from test environment.
+
+
 |Variable|Scope|Description|Default|
 | :---: | :---: | :---: | :---: |
 |DATA_CONNECT|Api|The database connection URL for api database|The enviromental variable DATABASE_URL|
@@ -47,6 +57,15 @@ They may be set in user's environment, or in the user environment file .env.
 
 These variables determiens the authentication database access. They may be set in the 
 user's environment, or in the user environment file .env.
+
+The development settigns may assign development specific variables to the ".env.development", but the 
+shared environment file ".env" overwrites any changes in that file. 
+
+Similar fashion the production specific variables may be put into the ".env.production", but the 
+shared environment file ".env" overwrites any changes in that file. 
+
+Test environment may be assigned to the ".env.test", but test environment variables has to be given
+"VITE_"-prefix due vitest security protecting the environment from test environment.
 
 |Variable|Scope|Description|Default|
 | :---: | :---: | :---: | :---: |
@@ -70,6 +89,15 @@ sequence, and reference priviledges for the database.
 The administartor access uses corresponding user database variables except connection, user, and password
 variables, which are replaced with variables: 
 
+The development settigns may assign development specific variables to the ".env.development", but the 
+shared environment file ".env" overwrites any changes in that file. 
+
+Similar fashion the production specific variables may be put into the ".env.production", but the 
+shared environment file ".env" overwrites any changes in that file. 
+
+Test environment may be assigned to the ".env.test", but test environment variables has to be given
+"VITE_"-prefix due vitest security protecting the environment from test environment.
+
 |Variable|Type|Description|Default|
 | :---: | :---: | :---: | :---: |
 |DATA_ADMIN_CONNECT|Api|The administrator database connection URL for api database|The api database connection url (process.env.DATA_CONNECT) or use variables below|
@@ -83,27 +111,20 @@ variables, which are replaced with variables:
 
 ## Database initialization
 
+The heroku database initialization can be used to populate existing local database.
+Replace the "local_database" with local database used for the application. Update the database
+connection to the .env files or environmental variables. 
 
-If the authentication and api databases does not exist, they may be created 
-by runing following commands: 
+#### Unix and Mac users 
 ```bash
-npx script/script/dbadmin.js --populate create db all
+npm run heroku:db:init:local -- local_database
 ```
-The former command populates the arts, ranges, spells, and spell guidelines.
 
-If an existing authentication database needs replaced with clean database, run
-following command:
-```bash
-npx script/script/dbadmin.js --init create db auth
-``` 
+#### Windows users using command prompt
 
-If an existing api database needs replaced with clean database, run
-following command:
-```bash
-npx script/script/dbadmin.js --init create db api
-``` 
-
-
+```cmd.exe
+npm run heroku:db:init:local:win -- local_database
+```
 
 ## Running 
 


### PR DESCRIPTION
Added details to the database initialization allowing use of the heroku local database initialization to initialize the database.

Changes to be committed:
	modified:   README.md
    - doc: initialize database.
    - doc: Environmental variables, and the environmental variable
    storage files.